### PR TITLE
Update circleci ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   linux_executor:
     machine:
-      image: ubuntu-1604:201903-01
+        image: ubuntu-2004:202201-02
 
 commands:
   test_steps:


### PR DESCRIPTION
CircleCI deprecation post: https://circleci.com/blog/ubuntu-14-16-image-deprecation/